### PR TITLE
confining battery facts to laptops using the mac_laptop fact

### DIFF
--- a/lib/facter/mac_battery_charge_percent.rb
+++ b/lib/facter/mac_battery_charge_percent.rb
@@ -1,6 +1,7 @@
 #mac_battery_charge_percent.rb
 Facter.add(:mac_battery_charge_percent) do
   confine :kernel => "Darwin"
+  confine :mac_laptop => "mac_laptop"
   setcode do
     max_capacity = Facter::Util::Resolution.exec("ioreg -r -c 'AppleSmartBattery' | grep -w 'MaxCapacity' | awk '{print $3}'")
     

--- a/lib/facter/mac_battery_charging.rb
+++ b/lib/facter/mac_battery_charging.rb
@@ -1,6 +1,7 @@
 #mac_battery_charging.rb
 Facter.add(:mac_battery_charging) do
   confine :kernel => "Darwin"
+  confine :mac_laptop => "mac_laptop"
   setcode do
     Facter::Util::Resolution.exec("/usr/sbin/ioreg -r -c 'AppleSmartBattery' | /usr/bin/grep -w 'IsCharging' | /usr/bin/awk '{print $3}'")
   end

--- a/lib/facter/mac_battery_cycles.rb
+++ b/lib/facter/mac_battery_cycles.rb
@@ -1,6 +1,7 @@
 #mac_battery_cycles.rb
 Facter.add(:mac_battery_cycles) do
   confine :kernel => "Darwin"
+  confine :mac_laptop => "mac_laptop"
   setcode do
     Facter::Util::Resolution.exec("/usr/sbin/ioreg -r -c 'AppleSmartBattery' | grep -w 'CycleCount' | awk '{print $3}'")
   end

--- a/lib/facter/mac_battery_health.rb
+++ b/lib/facter/mac_battery_health.rb
@@ -1,6 +1,7 @@
 #mac_battery_health.rb
 Facter.add(:mac_battery_health) do
   confine :kernel => "Darwin"
+  confine :mac_laptop => "mac_laptop"
   setcode do
     batt_status = Facter::Util::Resolution.exec("/usr/sbin/ioreg -r -c 'AppleSmartBattery' | /usr/bin/grep 'PermanentFailureStatus' | /usr/bin/awk '{print $3}'")
     


### PR DESCRIPTION
This is to avoid the following error on machines that don't have a battery

Could not retrieve fact='mac_battery_charge_percent', resolution='<anonymous>': invalid value for Float(): ""

cheers

Matt
