### PR TITLE
Add fact to display the current user's full name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Whether the battery has failed or not
 
 This fact displays the current user logged into the console.
 
+###mac_current_user_full_name
+
+Display the current user's full name
+
 ###mac_encryption_enabled
 
 Returns true if FileVault 2 is enabled (only compatible with Mac OS X 10.8 and higher).

--- a/lib/facter/mac_current_user_full_name.rb
+++ b/lib/facter/mac_current_user_full_name.rb
@@ -1,0 +1,13 @@
+# mac_current_user_full_name.rb
+Facter.add(:mac_current_user_full_name) do
+  # Limit this fact to macOS only
+  confine :kernel => 'Darwin'
+  setcode do
+    # Assign external 'mac_current_user' fact to current_user
+    current_user = Facter.value(:mac_current_user)
+    # Creating shell command and passing in current_user
+    shell_command = "/usr/bin/id -F #{current_user}"
+    # Execute shell command
+    Facter::Core::Execution.execute(shell_command)
+  end
+end


### PR DESCRIPTION
I'm using this fact to display the current user's full name by using your 'mac_current_user' fact as a variable. As an example:

```
'mac_current_user' = paulgalow
'mac_current_user_full_name' = Paul Galow
```

As I'm using your great collection of Mac facts I'd like to propose adding this fact. I'm successfully running this on Puppet v5.3.2 with Facter v3.9.2 (server side) and on macOS 10.12.6 and 10.13.1 (client side).

Perhaps this is useful to anyone else.